### PR TITLE
Fix include for linux which is case-sensative

### DIFF
--- a/Queue.h
+++ b/Queue.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #if defined(ARDUINO) && ARDUINO >= 100
-#include "arduino.h"
+#include "Arduino.h"
 #else
 #include "WProgram.h"
 #endif


### PR DESCRIPTION
Fails on linux with:
Build options changed, rebuilding all
In file included from XXXX:
~/Arduino/libraries/ArduinoQueue/Queue.h:12:21: fatal error: arduino.h: No such file or directory
 #include "arduino.h"

This fixes it.
Also added a new line at the end to make the file POSIX (See: https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline )