### PR TITLE
Major updates for ESP8266. Changed constructors with configurable items count and/or bytes size

### DIFF
--- a/Queue.h
+++ b/Queue.h
@@ -9,13 +9,13 @@
 #pragma once
 
 #if defined(ARDUINO) && ARDUINO >= 100
-#include "Arduino.h"
+#include "arduino.h"
 #else
 #include "WProgram.h"
 #endif
 
 template <typename T>
-class Queue {
+class DataQueue {
 	class Node {
 	public:
 		T item;
@@ -31,13 +31,19 @@ class Queue {
 	};
 	Node* head;
 	Node* tail;
+  uint8_t max_items;
+  uint8_t items;
 public:
-	Queue() {
+	DataQueue(int m_size = 100) {
 		head = NULL;
 		tail = NULL;
+    if (m_size > 255) m_size = 255;
+    if (m_size < 0) m_size = 0;
+    max_items = m_size;
+    items = 0;
 	}
 
-	~Queue() {
+	~DataQueue() {
 		for (Node* node = head; node != NULL; node = head) {
 			head = node->next;
 			delete node;
@@ -46,6 +52,10 @@ public:
 
 	// Returns false if memory is full, otherwise true
 	bool enqueue(T item) {
+    if (items == max_items) {
+      return false;
+    }
+    
 		Node* node = new Node;
 		if (node == NULL) {
 			return false;
@@ -56,12 +66,14 @@ public:
 		if (head == NULL) {
 			head = node;
 			tail = node;
+      items++;
 			return true;
 		}
 
 		tail->next = node;
 		tail = node;
-
+    items++;
+    
 		return true;
 	}
 
@@ -74,7 +86,7 @@ public:
 		returned.
 	*/
 	T dequeue() {
-		if (head == NULL) {
+		if ((items == 0) || (head == NULL)) {
 			return T();
 		}
 
@@ -88,12 +100,33 @@ public:
 			tail = NULL;
 		}
 
+    items--;
 		return item;
 	}
 
+  /*
+		Returns true if the queue
+    is empty, false otherwise.
+	*/
 	bool isEmpty() {
 		return head == NULL;
 	}
+  
+  /*
+		Returns true if the queue
+    is full, false otherwise.
+	*/
+  bool isFull() {
+		return items == max_items;
+	}
+
+  /*
+		Returns the number of items
+    in the queue.
+	*/
+  uint8_t count() {
+    return items;
+  }
 
 	/*
 		Get the front of the queue.
@@ -104,7 +137,7 @@ public:
 		returned.
 	*/
 	T front() {
-		if (head == NULL) {
+		if ((items == 0) || (head == NULL)) {
 			return T();
 		}
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,51 @@
 A lightweight linked list type queue implementation, meant for microcontrollers.
 Written as a C++ template class.
 
-## Example:
-`Queue<int> intQueue;`
+## Constructor:
+```
+DataQueue<T> intQueue(maximum_number_of_items);
+```
 
-all the T's will then be replaced by int.
+## How to use:
+Include the header file on your code:
+```
+#include <Queue.h>
+```
 
+Then create the queue according to your needs, examples:
+
+* To create a queue of **int**, capable of holding 20 items:
+```
+DataQueue<int> intQueue(20);
+```
+
+* To create a queue of your ***defined structure***, capable of holding 50 items:
+```
+struct car {
+    char brand[10];
+    char model[10];
+    int nr_doors;
+};
+DataQueue<car> myCarsQueue(50);
+```
+
+Finally use the following functions:
+```
+intQueue.enqueue(1);    // Adds number 1 to the queue
+intQueue.enqueue(123);    // Adds number 123 to the queue
+int number = intQueue.dequeue()    // Will return number 1 and remove it from the queue
+int number = intQueue.front()    // Will return number 123 but leave it still in the queue
+int number = intQueue.dequeue()    // Will return number 123 and remove it from the queue
+```
+
+You can use also the following functions for getting queue properties:
+```
+bool state = intQueue.isEmpty();    // Returns true if the queue is empty, false otherwise
+bool state = intQueue.isFull();    // Returns true if the queue is full, false otherwise
+uint8_t number = intQueue.count()    // Returns the number of items on the queue
+```
+
+## Notes
 Note that while the Queue class cleans up the nodes in memory after destructor or dequeue is called, it keeps a copy of the item being queued. So for example if you are queuing pointers, you will need to keep track of the memory behind them.
+
+Note that this library was made in order to be lightweight and the maximum number of items is stored in an 8 bit unsigned number, so the **maximum number of items is 255**. If you wish to have a bigger queue *(be careful with the memory requirements!)* you may change the internal item counters from `uint8_t` *(up to 255 items)* to `uint16_t` *(up to 65.534 items)* or `uint32_t` *(up to 4.294.967.294 items)*

--- a/README.md
+++ b/README.md
@@ -2,9 +2,18 @@
 A lightweight linked list type queue implementation, meant for microcontrollers.
 Written as a C++ template class.
 
-## Constructor:
+## Constructors:
+Creates a queue up to *<maximum_number_of_items>* items:
 ```
 DataQueue<T> intQueue(maximum_number_of_items);
+```
+Creates a queue up to *<maximum_size_in_bytes>* bytes:
+```
+DataQueue<T> intQueue(0, maximum_size_in_bytes);
+```
+Creates a queue up to *<maximum_number_of_items>* items or *<maximum_size_in_bytes>* bytes, whatever comes first:
+```
+DataQueue<T> intQueue(maximum_number_of_items, maximum_size_in_bytes);
 ```
 
 ## How to use:
@@ -15,9 +24,14 @@ Include the header file on your code:
 
 Then create the queue according to your needs, examples:
 
-* To create a queue of **int**, capable of holding 20 items:
+* To create a queue of ***int***, capable of holding 20 items:
 ```
 DataQueue<int> intQueue(20);
+```
+
+* To create a queue of ***int***, capable of holding 20 items or a maximum size of 10 bytes *(whatever comes first)*:
+```
+DataQueue<int> intQueue(20, 10);
 ```
 
 * To create a queue of your ***defined structure***, capable of holding 50 items:
@@ -34,19 +48,22 @@ Finally use the following functions:
 ```
 intQueue.enqueue(1);    // Adds number 1 to the queue
 intQueue.enqueue(123);    // Adds number 123 to the queue
-int number = intQueue.dequeue()    // Will return number 1 and remove it from the queue
-int number = intQueue.front()    // Will return number 123 but leave it still in the queue
-int number = intQueue.dequeue()    // Will return number 123 and remove it from the queue
+int number = intQueue.dequeue();    // Will return number 1 and remove it from the queue
+int number = intQueue.front();    // Will return number 123 but leave it still in the queue
+int number = intQueue.dequeue();    // Will return number 123 and remove it from the queue
 ```
 
-You can use also the following functions for getting queue properties:
+You can use also the following functions to get more queue properties:
 ```
 bool state = intQueue.isEmpty();    // Returns true if the queue is empty, false otherwise
 bool state = intQueue.isFull();    // Returns true if the queue is full, false otherwise
-uint8_t number = intQueue.count()    // Returns the number of items on the queue
+unsigned int n = intQueue.item_count();    // Returns the number of items currently on the queue
+unsigned int n = intQueue.item_size();    // Returns the size of the item being stored (bytes)
+unsigned int n = intQueue.max_queue_size();    // Returns the maximum possible size of the queue (items)*
+unsigned int n = intQueue.max_memory_size();    // Returns the maximum possible size of the queue (bytes)*
 ```
 
 ## Notes
 Note that while the Queue class cleans up the nodes in memory after destructor or dequeue is called, it keeps a copy of the item being queued. So for example if you are queuing pointers, you will need to keep track of the memory behind them.
 
-Note that this library was made in order to be lightweight and the maximum number of items is stored in an 8 bit unsigned number, so the **maximum number of items is 255**. If you wish to have a bigger queue *(be careful with the memory requirements!)* you may change the internal item counters from `uint8_t` *(up to 255 items)* to `uint16_t` *(up to 65.534 items)* or `uint32_t` *(up to 4.294.967.294 items)*
+*For example if you create a queue of *int* on an ESP8266, where each *int* has a size of 4 bytes and you specify the queue sizes to be up to 10 items and 10 bytes on the constructor, actually the real values will be 2 items and 8 bytes. These will be the values returned by *max_queue_size()* and *max_memory_size()*.

--- a/examples/intQueueItemsSize/intQueueItemsSize.ino
+++ b/examples/intQueueItemsSize/intQueueItemsSize.ino
@@ -1,0 +1,73 @@
+/*
+	Author: Vasco Baptista
+	email: vascojdb@gmail.com
+
+	An example of using Einar Arnason's queue
+	In this example we create a queue of int's
+	limited by the maximum amount of items
+	
+	Usage and further info:
+	https://github.com/EinarArnason/ArduinoQueue
+*/
+
+#include "Queue.h"
+
+#define QUEUE_SIZE_ITEMS 10
+
+// Queue creation:
+DataQueue<int> intQueue(QUEUE_SIZE_ITEMS);
+
+void printQueueStats() {
+	Serial.println("");
+	Serial.printf("Size of each element:    %u bytes\r\n", intQueue.item_size());
+	Serial.printf("Items in queue now:      %u items\r\n", intQueue.item_count());
+	Serial.printf("Queue actual max items:  %u items\r\n", intQueue.max_queue_size());
+	Serial.printf("Queue actual max memory: %u bytes\r\n", intQueue.max_memory_size());
+	Serial.println("");
+}
+
+void setup() {
+	Serial.begin(115200);
+	Serial.println("");
+	Serial.println("========== Queue example ==========");
+	Serial.printf("Desired max item size:  %u items\r\n", QUEUE_SIZE_ITEMS);
+	Serial.println("===================================");
+}
+
+void loop() {
+	printQueueStats();
+	
+	// Add elements: (add more than the queue size for demo purposes)
+	for(int n=1; n<QUEUE_SIZE_ITEMS+5; n++) {
+		if (!intQueue.isFull()) {
+			Serial.printf("Adding value: %i\r\n", n);
+			intQueue.enqueue(n);
+		}
+		else {
+			Serial.println("Queue is full!");
+		}
+	}
+	
+	printQueueStats();
+	
+	// Remove elements: (remove more than the queue size for demo purposes)
+	for(int n=1; n<QUEUE_SIZE_ITEMS+5; n++) {
+		if (!intQueue.isEmpty()) {
+			
+			int value = intQueue.dequeue();
+			Serial.printf("Removed value: %i\r\n", value);
+		}
+		else {
+			Serial.println("Queue is empty!");
+		}
+	}
+	
+	printQueueStats();
+
+	// Loop forever
+	while(true) {
+		#ifdef ESP8266
+		ESP.wdtFeed();
+		#endif
+	}
+}

--- a/examples/intQueueMemSize/intQueueMemSize.ino
+++ b/examples/intQueueMemSize/intQueueMemSize.ino
@@ -1,0 +1,77 @@
+/*
+	Author: Vasco Baptista
+	email: vascojdb@gmail.com
+
+	An example of using Einar Arnason's queue
+	In this example we create a queue of int's
+	limited by the maximum amount of items and
+	by the maximum size in bytes, limited by
+	whatever comes first
+	
+	Usage and further info:
+	https://github.com/EinarArnason/ArduinoQueue
+*/
+
+#include "Queue.h"
+
+#define QUEUE_SIZE_ITEMS 10
+#define QUEUE_SIZE_BYTES 10
+
+// Queue creation:
+DataQueue<int> intQueue(QUEUE_SIZE_ITEMS, QUEUE_SIZE_BYTES);
+
+void printQueueStats() {
+	Serial.println("");
+	Serial.printf("Size of each element:    %u bytes\r\n", intQueue.item_size());
+	Serial.printf("Items in queue now:      %u items\r\n", intQueue.item_count());
+	Serial.printf("Queue actual max items:  %u items\r\n", intQueue.max_queue_size());
+	Serial.printf("Queue actual max memory: %u bytes\r\n", intQueue.max_memory_size());
+	Serial.println("");
+}
+
+void setup() {
+	Serial.begin(115200);
+	Serial.println("");
+	Serial.println("========== Queue example ==========");
+	Serial.printf("Desired max item size:  %u items\r\n", QUEUE_SIZE_ITEMS);
+	Serial.printf("Desired max queue size: %u bytes\r\n", QUEUE_SIZE_BYTES);
+	Serial.println("===================================");
+}
+
+void loop() {
+	printQueueStats();
+	
+	// Add elements: (add more than the queue size for demo purposes)
+	for(int n=1; n<QUEUE_SIZE_ITEMS+5; n++) {
+		if (!intQueue.isFull()) {
+			Serial.printf("Adding value: %i\r\n", n);
+			intQueue.enqueue(n);
+		}
+		else {
+			Serial.println("Queue is full!");
+		}
+	}
+	
+	printQueueStats();
+	
+	// Remove elements: (remove more than the queue size for demo purposes)
+	for(int n=1; n<QUEUE_SIZE_ITEMS+5; n++) {
+		if (!intQueue.isEmpty()) {
+			
+			int value = intQueue.dequeue();
+			Serial.printf("Removed value: %i\r\n", value);
+		}
+		else {
+			Serial.println("Queue is empty!");
+		}
+	}
+	
+	printQueueStats();
+
+	// Loop forever
+	while(true) {
+		#ifdef ESP8266
+		ESP.wdtFeed();
+		#endif
+	}
+}


### PR DESCRIPTION
The following was changed:
* Changed name Queue to DataQueue because of ESP8266 already including a conflicting name. This will solve the compilation errors.
* Added a maximum limit for number of items in queue and an optional limit for size of the queue in bytes (now the user can create a queue based on the max number of items and/or on the maximum size in bytes)
* Added functions: item_count(), item_size(), max_queue_size(), max_memory_size()
* Updated README for a more complete documentation
* Added 2 examples, one for a item limited queue and other for a size (bytes) limited queue, showing the use of all functions

Tested on:
* ESP8266